### PR TITLE
make @info outputs optional through printflag

### DIFF
--- a/examples/workflow_example_cep.jl
+++ b/examples/workflow_example_cep.jl
@@ -43,4 +43,4 @@ transmission_result = run_opt(ts_clust_data.best_results,cep_data;solver=solver,
 # First solve the clustered case
 design_result = run_opt(ts_clust_data.best_results,cep_data;solver=solver,descriptor="design&operation")
 # Use the design variable results for the operational run
-operation_result = run_opt(ts_full_data.best_results,cep_data,design_result.opt_config,get_cep_design_variables(design_result);solver=solver,slack_cost=1e8)
+operation_result = run_opt(ts_full_data.best_results,cep_data,design_result.opt_config,get_cep_design_variables(design_result);solver=solver,slack_cost=1e8);

--- a/src/optim_problems/opt_cep.jl
+++ b/src/optim_problems/opt_cep.jl
@@ -504,9 +504,9 @@ function solve_opt_cep(cep::OptModelCEP,
   end
   currency=variables["COST"].axes[2][1]
   if slack==0
-    @info("Solved Scenario $(opt_config["descriptor"]): "*String(status)*" min COST[$currency]: $objective s.t. CO₂-Emissions per MWh ≤ $(opt_config["co2_limit"])")
+    opt_config["print_flag"] && @info("Solved Scenario $(opt_config["descriptor"]): "*String(status)*" min COST[$currency]: $objective s.t. CO₂-Emissions per MWh ≤ $(opt_config["co2_limit"])")
   else
-    @warn("Solved Scenario $(opt_config["descriptor"]): "*String(status)*" with SLACK $slack MWh s.t. CO₂-Emissions per MWh ≤ $(opt_config["co2_limit"])")
+    opt_config["print_flag"] && @info("Solved Scenario $(opt_config["descriptor"]): "*String(status)*" with SLACK $slack MWh s.t. CO₂-Emissions per MWh ≤ $(opt_config["co2_limit"])")
   end
   return OptResult(status,objective,variables,cep.set,cep.info,opt_config)
 end

--- a/src/optim_problems/run_opt.jl
+++ b/src/optim_problems/run_opt.jl
@@ -84,7 +84,8 @@ function run_opt(ts_data::ClustData,
                  limit_infrastructure::Bool=false,
                  storage::String="non",
                  transmission::Bool=false,
-                 k_ids::Array{Int64,1}=Array{Int64,1}())
+                 k_ids::Array{Int64,1}=Array{Int64,1}(),
+                 print_flag::Bool=true)
    # Activated inter or intraday storage corresponds with storage
    if storage=="inter"
        storage=true
@@ -104,7 +105,7 @@ function run_opt(ts_data::ClustData,
      throw(@error("No or empty k_ids provided"))
    end
   #Setup the opt_config file based on the data input and
-  opt_config=set_opt_config_cep(opt_data; descriptor=descriptor, co2_limit=co2_limit, slack_cost=slack_cost, existing_infrastructure=existing_infrastructure, limit_infrastructure=limit_infrastructure, storage_e=storage, storage_p=storage, interstorage=interstorage, transmission=transmission)
+  opt_config=set_opt_config_cep(opt_data; descriptor=descriptor, co2_limit=co2_limit, slack_cost=slack_cost, existing_infrastructure=existing_infrastructure, limit_infrastructure=limit_infrastructure, storage_e=storage, storage_p=storage, interstorage=interstorage, transmission=transmission, print_flag=print_flag)
   #Run the optimization problem
   run_opt(ts_data, opt_data, opt_config; solver=solver, k_ids=k_ids)
 end # run_opt


### PR DESCRIPTION
- make @info optional (useful for many runs in a row)
- replace `@warn` by `@info` for slack variables: In many CEPs, using slack variables is a default, so I think treating it as an info is ok. 